### PR TITLE
Curve points editing

### DIFF
--- a/src/course_generator/param/ParamData.java
+++ b/src/course_generator/param/ParamData.java
@@ -27,7 +27,6 @@ import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 
-import course_generator.utils.CgConst;
 import course_generator.utils.Utils;
 
 /**
@@ -63,7 +62,7 @@ public class ParamData {
 	 * Save parameters on disk
 	 * @param fname Name of the file
 	 */
-	public void Save(String fname,int unit) {
+	public void SaveCurve(String fname,int unit) {
 		if (data.size() <= 0) {
 			return;
 		}
@@ -71,20 +70,24 @@ public class ParamData {
 		// -- Save the data in the home directory
 		XMLOutputFactory factory = XMLOutputFactory.newInstance();
 		try {
-			XMLStreamWriter writer = factory.createXMLStreamWriter(new FileOutputStream(fname), "UTF-8");
+			XMLStreamWriter writer = factory.createXMLStreamWriter(
+					new FileOutputStream(fname), "UTF-8");
 			writer.writeStartDocument("UTF-8", "1.0");
 			writer.writeStartElement("Project");
 			Utils.WriteStringToXML(writer, "Name", name);
 			Utils.WriteStringToXML(writer, "Comment", comment);
 			writer.writeStartElement("Param");
-			for (CgParam r : data) {
+			for (CgParam curvePoint : data) {
 				writer.writeStartElement("Item");
-				Utils.WriteStringToXML(writer, "Slope", String.format(Locale.ROOT, "%f", r.Slope));
-				
-				if (unit==CgConst.UNIT_MILES_FEET)
-					Utils.WriteStringToXML(writer, "Speed", String.format(Locale.ROOT, "%f", Utils.Miles2Km(r.Speed)));
-				else
-					Utils.WriteStringToXML(writer, "Speed", String.format(Locale.ROOT, "%f", r.Speed));
+				Utils.WriteStringToXML(
+						writer, 
+						"Slope", 
+						String.format(Locale.ROOT, "%f", curvePoint.Slope));
+				// Saving the curve speeds using the metric system.
+				Utils.WriteStringToXML(
+						writer, 
+						"Speed",
+						String.format(Locale.ROOT, "%f", curvePoint.Speed));
 				writer.writeEndElement(); // Item
 			}
 			writer.writeEndElement(); // Param

--- a/src/course_generator/param/frmEditCurve.java
+++ b/src/course_generator/param/frmEditCurve.java
@@ -39,6 +39,8 @@ import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.JTextField;
 import javax.swing.JToolBar;
+import javax.swing.event.ListSelectionEvent;
+import javax.swing.event.ListSelectionListener;
 
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.ChartMouseEvent;
@@ -346,6 +348,13 @@ public class frmEditCurve extends javax.swing.JDialog {
 				//TODO
 			}
 		});
+		TablePoints.getSelectionModel()
+			.addListSelectionListener( new ListSelectionListener() {
+				@Override
+				public void valueChanged(ListSelectionEvent event) {
+					btEditLine.setEnabled(TablePoints.getSelectedRow() > 0);
+				}
+			});
 		
         jScrollPanePoint = new javax.swing.JScrollPane();
         jScrollPanePoint.setViewportView(TablePoints);
@@ -539,7 +548,9 @@ public class frmEditCurve extends javax.swing.JDialog {
 				if (bEditMode) {
 					param.comment = tfComment.getText();
 					param.name = lbNameVal.getText();
-			        param.Save(Utils.GetHomeDir() + "/"+CgConst.CG_DIR+"/"+Paramfile+".par", settings.Unit);
+			        param.SaveCurve(Utils.GetHomeDir() + "/" + 
+			        		CgConst.CG_DIR + "/"+ Paramfile +".par", 
+			        		settings.Unit);
 			        bEditMode = false;
 			        ChangeEditStatus();
 			        RefreshView();
@@ -680,6 +691,7 @@ public class frmEditCurve extends javax.swing.JDialog {
 		btEditCurve.setToolTipText(bundle.getString("frmEditCurve.btEditCurve.toolTipText"));
 		btEditCurve.addActionListener(new java.awt.event.ActionListener() {
 			public void actionPerformed(java.awt.event.ActionEvent evt) {
+				TablePoints.setRowSelectionInterval(0, 0);
 				bEditMode = true;
 			    ChangeEditStatus();
 			    Old_Paramfile = Paramfile;
@@ -772,7 +784,10 @@ public class frmEditCurve extends javax.swing.JDialog {
 				}
 				param.name = tfName.getText();
 				Paramfile = param.name;
-				param.Save(Utils.GetHomeDir() + "/"+CgConst.CG_DIR+"/" + param.name + ".par", settings.Unit);
+				param.SaveCurve(
+						Utils.GetHomeDir() + "/" + CgConst.CG_DIR + "/" +
+								param.name + ".par", 
+						settings.Unit);
 				ChangeEditStatus();
 				RefreshCurveList();
 				RefreshView();

--- a/src/course_generator/param/frmEditCurve.java
+++ b/src/course_generator/param/frmEditCurve.java
@@ -226,8 +226,6 @@ public class frmEditCurve extends javax.swing.JDialog {
 	 * This method is called to initialize the form.
 	 */
 	private void initComponents() {
-		int line = 0;
-
 		setDefaultCloseOperation(javax.swing.WindowConstants.DISPOSE_ON_CLOSE);
 		setTitle(bundle.getString("frmEditCurve.title"));
 		setPreferredSize(new Dimension(1200,600));
@@ -474,8 +472,6 @@ public class frmEditCurve extends javax.swing.JDialog {
 	 * @param filename Curve file name
 	 */
 	protected void LoadCurve(String filename) {
-		 File f = new File(filename);
-		 String sname=Utils.getFileNameWithoutExtension(f.getName());
 		
 		if (Utils.FileExist(filename)) {
 			
@@ -609,7 +605,7 @@ public class frmEditCurve extends javax.swing.JDialog {
 	 */
 	protected void AddLine() {
 		CgParam p=new CgParam(0,0);
-		frmEditPoint frm=new frmEditPoint();
+		frmEditPoint frm=new frmEditPoint(settings);
 		if (frm.showDialog(p)) {
 			param.data.add(p);
 			Collections.sort(param.data);
@@ -626,7 +622,7 @@ public class frmEditCurve extends javax.swing.JDialog {
 		int r=TablePoints.getSelectedRow();
 		if (r>=0) {
 			CgParam p=new CgParam(param.data.get(r).Slope,param.data.get(r).Speed);
-			frmEditPoint frm=new frmEditPoint();
+			frmEditPoint frm=new frmEditPoint(settings);
 			if (frm.showDialog(p)) {
 				param.data.set(r, p);
 				Collections.sort(param.data);

--- a/src/course_generator/param/frmEditPoint.java
+++ b/src/course_generator/param/frmEditPoint.java
@@ -36,6 +36,8 @@ import javax.swing.JRootPane;
 import javax.swing.JTextField;
 import javax.swing.KeyStroke;
 
+import course_generator.settings.CgSettings;
+import course_generator.utils.CgConst;
 import course_generator.utils.Utils;
 
 public class frmEditPoint extends javax.swing.JDialog {
@@ -51,12 +53,14 @@ public class frmEditPoint extends javax.swing.JDialog {
 	private JButton btOk;
 	private double slope;
 	private double speed;
+	private CgSettings settings;
 	
 	/**
 	 * Creates new form frmSettings
 	 */
-	public frmEditPoint() {
+	public frmEditPoint(CgSettings settings) {
 		super();
+		this.settings = settings;
 		bundle = java.util.ResourceBundle.getBundle("course_generator/Bundle");
 		initComponents();
 		setModal(true);
@@ -170,9 +174,11 @@ public class frmEditPoint extends javax.swing.JDialog {
 		slope=p.Slope;
 		speed=p.Speed;
 		
+		double convertedSpeed = settings.Unit == CgConst.UNIT_MILES_FEET ? Utils.Km2Miles(p.Speed): p.Speed;
+		
 		// Set field
-		tfSlope.setText(String.valueOf(param.Slope));
-		tfSpeed.setText(String.valueOf(param.Speed));
+		tfSlope.setText(String.valueOf(slope));
+		tfSpeed.setText(String.valueOf(convertedSpeed));
 		// End set field
 		ok = false;
 
@@ -181,7 +187,7 @@ public class frmEditPoint extends javax.swing.JDialog {
 		if (ok) {
 			// Copy fields
 			p.Slope=slope;
-			p.Speed=speed;
+			p.Speed=settings.Unit == CgConst.UNIT_MILES_FEET ? Utils.Miles2Km(speed) : speed;
 		}
 		return ok;
 	}


### PR DESCRIPTION
Fixing a bug where we were not displaying and saving the curves speeds correctly when using imperial system.
We disable the edit button when a row is not selected (using an action listener). Now, the first line is selected.