### PR TITLE
Bugfix for times when loading GPX and CGX

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 		<dependency>
 			<groupId>joda-time</groupId>
 			<artifactId>joda-time</artifactId>
-			<version>2.10</version>
+			<version>2.10.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.swinglabs.swingx</groupId>

--- a/src/course_generator/SaxGPXHandler.java
+++ b/src/course_generator/SaxGPXHandler.java
@@ -20,12 +20,14 @@ package course_generator;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.TimeZone;
 
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.joda.time.Interval;
 import org.xml.sax.Attributes;
 import org.xml.sax.Locator;
@@ -33,6 +35,7 @@ import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 
 import course_generator.utils.CgConst;
+import course_generator.utils.Utils;
 
 /**
  *
@@ -246,7 +249,12 @@ public class SaxGPXHandler extends DefaultHandler {
 			try {
 				if (first) {
 					first = false;
-					trkpt_time = DateTime.parse(characters);
+
+					// Fetch the timezone to populate for each track point time.
+					// Determine the course time zone
+					TimeZone timeZoneId = Utils.getTimeZoneFromLatLon(trkpt_lat, trkpt_lon);
+					trkpt_time = DateTime.parse(characters).withZone(DateTimeZone.forTimeZone(timeZoneId));
+
 					StartTime = trkpt_time;
 					old_time = StartTime;
 					Time_s = 0;

--- a/src/course_generator/TrackData.java
+++ b/src/course_generator/TrackData.java
@@ -399,6 +399,8 @@ public class TrackData {
 		CalcClimbResult resClimb = new CalcClimbResult();
 		CalcClimb(0, data.size() - 1, resClimb); // ref ClimbP, ref ClimbM, ref
 													// AscTime, ref DescTime);
+		StartTime = data.get(0).getHour();
+
 		ClimbP = resClimb.cp;
 		ClimbM = resClimb.cm;
 		AscTime = resClimb.tp;
@@ -415,7 +417,7 @@ public class TrackData {
 		MaxElev = resMinMaxElev.max;
 
 		SetNightBit();
-		
+
 		isCalculated = true;
 		Name = new File(name).getName();
 
@@ -1208,12 +1210,12 @@ public class TrackData {
 	// -- Calculate road distance (in meter) --
 	public double CalcRoad(int start, int end) {
 		double road = 0.0;
-		//DistRoad = 0.0;
-		//for (CgData r : data) {
-		for (int i=start; i<end; i++) {
+		// DistRoad = 0.0;
+		// for (CgData r : data) {
+		for (int i = start; i < end; i++) {
 			CgData r = data.get(i);
 			if (r.getDiff() == 100) {
-				//DistRoad = DistRoad + r.getDist(CgConst.UNIT_METER);
+				// DistRoad = DistRoad + r.getDist(CgConst.UNIT_METER);
 				road = road + r.getDist(CgConst.UNIT_METER);
 			}
 		}
@@ -1374,7 +1376,7 @@ public class TrackData {
 				night = 1;
 				r.setNight(false);
 			}
-			
+
 			// --Elev effect --
 			if (bElevEffect && ((double) r.getElevation(CgConst.UNIT_METER) > 1500.0)) {
 				ef = 1.0 + (Math.round(((double) r.getElevation(CgConst.UNIT_METER) - 1500.0) / 100.0) / 100.0);
@@ -1414,18 +1416,18 @@ public class TrackData {
 			r.setHour(StartTime.plusSeconds((int) (Math.round(dt))));
 		} // End of the calculation loop --
 
-		//-- Update the road distance for the track
-		DistRoad = CalcRoad(0, data.size()-1);
-		
+		// -- Update the road distance for the track
+		DistRoad = CalcRoad(0, data.size() - 1);
+
 		TotalTime = (int) Math.round(dt);
 		isCalculated = true;
 		isModified = true;
 	} // Calculate
 
-	
-	
+
 	/**
-	 * Set night bit. Used when we load a track to avoid to launch a new calculation to have the night display on the map
+	 * Set night bit. Used when we load a track to avoid to launch a new calculation
+	 * to have the night display on the map
 	 */
 	public void SetNightBit() {
 		// -- Calculation loop --
@@ -1437,7 +1439,7 @@ public class TrackData {
 			} else {
 				r.setNight(false);
 			}
-		} 	
+		}
 	} // SetNightBit
 
 
@@ -1461,11 +1463,11 @@ public class TrackData {
 		CgData r2 = null;
 		CgData r3 = null;
 
-		//-- Reset bit 0 & 1 of 'Tag' variable
+		// -- Reset bit 0 & 1 of 'Tag' variable
 		for (CgData r : data)
 			r.setTag((int) r.getTag() & 0xFC);
 
-		//-- Main loop
+		// -- Main loop
 		for (i = 0; i < data.size(); i++) {
 			r1 = data.get(i);
 
@@ -1545,7 +1547,7 @@ public class TrackData {
 				r1.setTag(r1.getTag() | CgConst.TAG_LOW_PT);
 			}
 
-		} //Main loop
+		} // Main loop
 	} // CalcMinMax
 
 
@@ -1605,35 +1607,16 @@ public class TrackData {
 			int n = start;
 			int nb = 0;
 			while (nb < data.size()) {
-				datatmp.add(new CgData((double) (nb + 1),
-						data.get(n).getLatitude(),
-						data.get(n).getLongitude(),
-						data.get(n).getElevation(CgConst.UNIT_METER), 
-						data.get(n).getElevationMemo(), 
-						data.get(n).getTag(), 
-						data.get(n).getDist(CgConst.UNIT_METER), 
-						data.get(n).getTotal(CgConst.UNIT_METER), 
-						data.get(n).getDiff(), 
-						data.get(n).getCoeff(),
-						0.0, 
-						data.get(n).getSlope(), 
-						data.get(n).getSpeed(CgConst.UNIT_METER), 
-						data.get(n).getdElevation(CgConst.UNIT_METER), 
-						data.get(n).getTime(), 
-						data.get(n).getdTime_f(), 
-						data.get(n).getTimeLimit(), 
-						data.get(n).getHour(), 
-						data.get(n).getStation(),
-						data.get(n).getName(), 
-						data.get(n).getComment(), 
-						0.0, 
-						0.0, 
-						data.get(n).FmtLbMiniRoadbook, 
-						data.get(n).OptionMiniRoadbook, 
-						data.get(n).VPosMiniRoadbook, 
-						data.get(n).CommentMiniRoadbook, 
-						data.get(n).FontSizeMiniRoadbook 
-				));
+				datatmp.add(new CgData((double) (nb + 1), data.get(n).getLatitude(), data.get(n).getLongitude(),
+						data.get(n).getElevation(CgConst.UNIT_METER), data.get(n).getElevationMemo(),
+						data.get(n).getTag(), data.get(n).getDist(CgConst.UNIT_METER),
+						data.get(n).getTotal(CgConst.UNIT_METER), data.get(n).getDiff(), data.get(n).getCoeff(), 0.0,
+						data.get(n).getSlope(), data.get(n).getSpeed(CgConst.UNIT_METER),
+						data.get(n).getdElevation(CgConst.UNIT_METER), data.get(n).getTime(), data.get(n).getdTime_f(),
+						data.get(n).getTimeLimit(), data.get(n).getHour(), data.get(n).getStation(),
+						data.get(n).getName(), data.get(n).getComment(), 0.0, 0.0, data.get(n).FmtLbMiniRoadbook,
+						data.get(n).OptionMiniRoadbook, data.get(n).VPosMiniRoadbook, data.get(n).CommentMiniRoadbook,
+						data.get(n).FontSizeMiniRoadbook));
 				nb++;
 				n++;
 				if (n >= data.size()) {
@@ -1643,26 +1626,26 @@ public class TrackData {
 
 			n = 0;
 			for (CgData r : data) {
-				r.setNum(datatmp.get(n).getNum()); 
-				r.setLatitude(datatmp.get(n).getLatitude()); 
-				r.setLongitude(datatmp.get(n).getLongitude()); 
-				r.setElevation(datatmp.get(n).getElevation(CgConst.UNIT_METER)); 
-				r.setElevationMemo(datatmp.get(n).getElevationMemo()); 
-				r.setTag(datatmp.get(n).getTag()); 
-				r.setDist(datatmp.get(n).getDist(CgConst.UNIT_METER)); 
-				r.setTotal(datatmp.get(n).getTotal(CgConst.UNIT_METER)); 
-				r.setDiff(datatmp.get(n).getDiff()); 
-				r.setCoeff(datatmp.get(n).getCoeff()); 
-				r.setSlope(datatmp.get(n).getSlope()); 
-				r.setSpeed(datatmp.get(n).getSpeed(CgConst.UNIT_METER)); 
-				r.setdElevation(datatmp.get(n).getdElevation(CgConst.UNIT_METER)); 
-				r.setTime(datatmp.get(n).getTime()); 
-				r.setdTime_f(datatmp.get(n).getdTime_f()); 
+				r.setNum(datatmp.get(n).getNum());
+				r.setLatitude(datatmp.get(n).getLatitude());
+				r.setLongitude(datatmp.get(n).getLongitude());
+				r.setElevation(datatmp.get(n).getElevation(CgConst.UNIT_METER));
+				r.setElevationMemo(datatmp.get(n).getElevationMemo());
+				r.setTag(datatmp.get(n).getTag());
+				r.setDist(datatmp.get(n).getDist(CgConst.UNIT_METER));
+				r.setTotal(datatmp.get(n).getTotal(CgConst.UNIT_METER));
+				r.setDiff(datatmp.get(n).getDiff());
+				r.setCoeff(datatmp.get(n).getCoeff());
+				r.setSlope(datatmp.get(n).getSlope());
+				r.setSpeed(datatmp.get(n).getSpeed(CgConst.UNIT_METER));
+				r.setdElevation(datatmp.get(n).getdElevation(CgConst.UNIT_METER));
+				r.setTime(datatmp.get(n).getTime());
+				r.setdTime_f(datatmp.get(n).getdTime_f());
 				r.setTimeLimit(datatmp.get(n).getTimeLimit());
-				r.setHour(datatmp.get(n).getHour()); 
-				r.setStation(datatmp.get(n).getStation()); 
-				r.setName(datatmp.get(n).getName()); 
-				r.setComment(datatmp.get(n).getComment()); 
+				r.setHour(datatmp.get(n).getHour());
+				r.setStation(datatmp.get(n).getStation());
+				r.setName(datatmp.get(n).getName());
+				r.setComment(datatmp.get(n).getComment());
 				r.FmtLbMiniRoadbook = data.get(n).FmtLbMiniRoadbook;
 				r.OptionMiniRoadbook = data.get(n).OptionMiniRoadbook;
 				r.VPosMiniRoadbook = data.get(n).VPosMiniRoadbook;
@@ -1754,7 +1737,7 @@ public class TrackData {
 		MaxElev = resMinMaxElev.max;
 
 		SetNightBit();
-		
+
 		CheckTimeLimit();
 		isCalculated = true;
 
@@ -2431,8 +2414,9 @@ public class TrackData {
 
 	/**
 	 * Return the road distance on the track
-	 * @param unit 
-	 * 		Unit for the returned value
+	 * 
+	 * @param unit
+	 *            Unit for the returned value
 	 * @return Road distance in meter
 	 */
 	public double getDistRoad(int unit) {
@@ -2461,10 +2445,10 @@ public class TrackData {
 
 	/**
 	 * Copy the current track to another
-	 * @param d 
-	 * 		track object where to copy the current track
-	 * @return
-	 * 		track object where the current is copied
+	 * 
+	 * @param d
+	 *            track object where to copy the current track
+	 * @return track object where the current is copied
 	 */
 	public TrackData CopyTo(TrackData d) {
 		int i = 0;

--- a/src/course_generator/dialogs/FrmCalcSunriseSunset.java
+++ b/src/course_generator/dialogs/FrmCalcSunriseSunset.java
@@ -26,11 +26,8 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ComponentEvent;
-import java.time.ZoneId;
-import java.util.Optional;
 import java.util.ResourceBundle;
 import java.util.TimeZone;
-import java.util.concurrent.TimeUnit;
 
 import javax.swing.AbstractAction;
 import javax.swing.Action;
@@ -52,8 +49,6 @@ import org.shredzone.commons.suncalc.SunTimes;
 import course_generator.settings.CgSettings;
 import course_generator.utils.CgSpinner;
 import course_generator.utils.Utils;
-import net.iakovlev.timeshape.TimeZoneEngine;
-//import net.iakovlev.timeshape.*;
 
 public class FrmCalcSunriseSunset extends javax.swing.JDialog {
 
@@ -62,6 +57,7 @@ public class FrmCalcSunriseSunset extends javax.swing.JDialog {
 	private boolean ok;
 	private double longitude;
 	private double latitude;
+	private TimeZone courseStartZone;
 	private DateTime sunrise;
 	private DateTime sunset;
 	private DateTime date;
@@ -82,8 +78,7 @@ public class FrmCalcSunriseSunset extends javax.swing.JDialog {
 	private JCheckBox chkSummerTime;
 	private JLabel lbDate;
 	private JLabel lbDateVal;
-	private TimeZoneEngine timeZoneEngine;
-	private TimeZone courseStartZone;
+
 	private CgSettings settings = null;
 
 	public class ResCalcSunriseSunset {
@@ -113,16 +108,16 @@ public class FrmCalcSunriseSunset extends javax.swing.JDialog {
 
 	public ResCalcSunriseSunset showDialog(double longitude, double latitude, DateTime starttime, int timezone,
 			boolean useDayLightSaving) {
-		
+
 		this.longitude = longitude;
 		this.latitude = latitude;
 		this.date = starttime;
 
 		// Determine the course time zone
-		Optional<ZoneId> courseStartZoneId = timeZoneEngine.query(latitude, longitude);
-		String timeZoneId = courseStartZoneId.get().getId();
-		courseStartZone = TimeZone.getTimeZone(timeZoneId);
-		long hoursOffsetFromUTC = TimeUnit.MILLISECONDS.toHours(courseStartZone.getRawOffset());
+		long hoursOffsetFromUTC = Utils.hoursUTCOffsetFromLatLon(latitude, longitude);
+		courseStartZone = Utils.getTimeZoneFromLatLon(latitude, longitude);
+		String timeZoneId = courseStartZone.getID();
+		boolean useDaylightTime = Utils.useDaylightTime(latitude, longitude);
 
 		// Set field
 		lbLongitudeVal.setText(String.format("%10.7f°", longitude));
@@ -130,7 +125,7 @@ public class FrmCalcSunriseSunset extends javax.swing.JDialog {
 		lbSunriseVal.setText("00:00");
 		lbSunsetVal.setText("00:00");
 		spinTimeZone.setValue(hoursOffsetFromUTC);
-		chkSummerTime.setSelected(courseStartZone.useDaylightTime());
+		chkSummerTime.setSelected(useDaylightTime);
 
 		lbDateVal.setText(this.date.toString("dd/MM/yyyy", getLocale()));
 
@@ -223,9 +218,6 @@ public class FrmCalcSunriseSunset extends javax.swing.JDialog {
 				formComponentShown(evt);
 			}
 		});
-
-		// Initialize the time zone engine
-		timeZoneEngine = TimeZoneEngine.initialize();
 
 		// -- Layout
 		// ------------------------------------------------------------

--- a/src/course_generator/dialogs/FrmCalcSunriseSunset.java
+++ b/src/course_generator/dialogs/FrmCalcSunriseSunset.java
@@ -117,7 +117,6 @@ public class FrmCalcSunriseSunset extends javax.swing.JDialog {
 		long hoursOffsetFromUTC = Utils.hoursUTCOffsetFromLatLon(latitude, longitude);
 		courseStartZone = Utils.getTimeZoneFromLatLon(latitude, longitude);
 		String timeZoneId = courseStartZone.getID();
-		boolean useDaylightTime = Utils.useDaylightTime(latitude, longitude);
 
 		// Set field
 		lbLongitudeVal.setText(String.format("%10.7f°", longitude));
@@ -125,7 +124,7 @@ public class FrmCalcSunriseSunset extends javax.swing.JDialog {
 		lbSunriseVal.setText("00:00");
 		lbSunsetVal.setText("00:00");
 		spinTimeZone.setValue(hoursOffsetFromUTC);
-		chkSummerTime.setSelected(useDaylightTime);
+		chkSummerTime.setSelected(courseStartZone.useDaylightTime());
 
 		lbDateVal.setText(this.date.toString("dd/MM/yyyy", getLocale()));
 

--- a/src/course_generator/dialogs/frmTrackSettings.java
+++ b/src/course_generator/dialogs/frmTrackSettings.java
@@ -28,7 +28,6 @@ import java.awt.event.ActionEvent;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.ResourceBundle;
-import java.util.TimeZone;
 
 import javax.swing.AbstractAction;
 import javax.swing.Action;
@@ -118,7 +117,8 @@ public class frmTrackSettings extends javax.swing.JDialog {
 		jMonthView.setSelectionDate(this.track.StartTime.toDate());
 		jMonthView.ensureDateVisible(this.track.StartTime.toDate());
 
-		spinStartTimeModel.setValue(this.track.StartTime.toDate());
+		Date date = Utils.DateTimetoSpinnerDate(this.track.StartTime);
+		spinStartTimeModel.setValue(date);
 		chkElevationEffect.setSelected(this.track.bElevEffect);
 		chkNightEffect.setSelected(this.track.bNightCoeff);
 		spinStartNightModel.setValue(this.track.StartNightTime.toDate());
@@ -332,28 +332,27 @@ public class frmTrackSettings extends javax.swing.JDialog {
 				setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
 
 				ResCalcSunriseSunset res = ShowCalcSunriseSunset();
-/*
-				if (calcSunriseSunset == null)
-					calcSunriseSunset = new FrmCalcSunriseSunset(settings);
+				/*
+				 * if (calcSunriseSunset == null) calcSunriseSunset = new
+				 * FrmCalcSunriseSunset(settings);
+				 * 
+				 * ResCalcSunriseSunset res =
+				 * calcSunriseSunset.showDialog(track.data.get(0).getLongitude(),
+				 * track.data.get(0).getLatitude(), track.StartTime,
+				 * track.TrackTimeZone.intValue(), track.TrackUseDaylightSaving);
+				 */
 
-				ResCalcSunriseSunset res = calcSunriseSunset.showDialog(track.data.get(0).getLongitude(),
-						track.data.get(0).getLatitude(), track.StartTime, track.TrackTimeZone.intValue(),
-						track.TrackUseDaylightSaving);
-*/
-				
 				setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
 
 				if (res.valid) {
 					timezone = Double.valueOf(res.TimeZone);
 					summertime = res.SummerTime;
 
-					Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone(res.TimeZoneId));
-					calendar.setTime(res.Sunrise.toDate());
+					Date date = Utils.DateTimetoSpinnerDate(res.Sunrise);
+					spinEndNightModel.setValue(date);
+					date = Utils.DateTimetoSpinnerDate(res.Sunset);
+					spinStartNightModel.setValue(date);
 
-					spinEndNightModel.setValue(calendar.getTime());
-					calendar.setTime(res.Sunset.toDate());
-
-					spinStartNightModel.setValue(calendar.getTime());
 				}
 			}
 		});
@@ -413,15 +412,16 @@ public class frmTrackSettings extends javax.swing.JDialog {
 		setLocationRelativeTo(null);
 	}
 
+
 	private ResCalcSunriseSunset ShowCalcSunriseSunset() {
 		if (calcSunriseSunset == null)
 			calcSunriseSunset = new FrmCalcSunriseSunset(this, settings);
 
-		return calcSunriseSunset.showDialog(track.data.get(0).getLongitude(),
-			track.data.get(0).getLatitude(), track.StartTime, track.TrackTimeZone.intValue(),
-			track.TrackUseDaylightSaving);
+		return calcSunriseSunset.showDialog(track.data.get(0).getLongitude(), track.data.get(0).getLatitude(),
+				track.StartTime, track.TrackTimeZone.intValue(), track.TrackUseDaylightSaving);
 	}
-	
+
+
 	protected void Refresh() {
 		spinStartNight.setEnabled(chkNightEffect.isSelected());
 		spinEndNight.setEnabled(chkNightEffect.isSelected());

--- a/src/course_generator/utils/Utils.java
+++ b/src/course_generator/utils/Utils.java
@@ -35,9 +35,15 @@ import java.net.UnknownHostException;
 import java.nio.file.Files;
 import java.text.DecimalFormat;
 import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.ZoneId;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
+import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
 
 import javax.swing.ImageIcon;
 import javax.swing.JComponent;
@@ -49,11 +55,14 @@ import javax.xml.stream.XMLStreamWriter;
 
 //import org.jdom2.Element;
 import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
 
 import course_generator.CgData;
 import course_generator.TrackData;
 import course_generator.TrackData.CalcClimbResult;
 import course_generator.settings.CgSettings;
+import net.iakovlev.timeshape.TimeZoneEngine;
 
 /**
  *
@@ -62,6 +71,8 @@ import course_generator.settings.CgSettings;
 public class Utils {
 
 	public static final String htmlDocFile = "cg_doc_4.00.html";
+
+	private static TimeZoneEngine timeZoneEngine;
 
 
 	/**
@@ -1495,6 +1506,59 @@ public class Utils {
 			CgLog.info("The help file '" + helpFilePath + "' was not found.");
 		}
 		return success;
+	}
+
+
+	public static TimeZone getTimeZoneFromLatLon(double latitude, double longitude) {
+		if (timeZoneEngine == null) {
+			// Initialize the time zone engine
+			timeZoneEngine = TimeZoneEngine.initialize();
+		}
+
+		Optional<ZoneId> courseStartZoneId = timeZoneEngine.query(latitude, longitude);
+		String timeZoneId = courseStartZoneId.get().getId();
+		return TimeZone.getTimeZone(timeZoneId);
+	}
+
+
+	public static int hoursUTCOffsetFromLatLon(double latitude, double longitude) {
+		TimeZone gpsPointTimeZone = getTimeZoneFromLatLon(latitude, longitude);
+		long hoursOffsetFromUTC = TimeUnit.MILLISECONDS.toHours(gpsPointTimeZone.getRawOffset());
+
+		return (int) hoursOffsetFromUTC;
+	}
+
+
+	public static boolean useDaylightTime(double latitude, double longitude) {
+		TimeZone gpsPointTimeZone = getTimeZoneFromLatLon(latitude, longitude);
+		return gpsPointTimeZone.useDaylightTime();
+	}
+
+
+	/**
+	 * Converts a Joda-Time to a date for a SpinnerDateModel. The particularity of
+	 * the SpinnerDateModel is that it is time zone agnostic. Hence we need to keep
+	 * the time at the given time zone but pretend that its time zone is UTC.
+	 * Example : Input : 07:50:00 UTC-7 ==> Output : 07:50:00 UTC
+	 * 
+	 * @param dateTime
+	 *            A Joda-Time.
+	 * @return A Date.
+	 * 
+	 */
+	public static Date DateTimetoSpinnerDate(DateTime dateTime) {
+		Date spinnerDate = null;
+		String datePattern = "yyyy-MM-dd HH:mm:ss";
+		DateTimeFormatter fmt = DateTimeFormat.forPattern(datePattern);
+		String date = fmt.print(dateTime);
+		SimpleDateFormat parser = new SimpleDateFormat(datePattern);
+		try {
+			spinnerDate = parser.parse(date);
+		} catch (ParseException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		return spinnerDate;
 	}
 
 } // Class

--- a/src/course_generator/utils/Utils.java
+++ b/src/course_generator/utils/Utils.java
@@ -1529,12 +1529,6 @@ public class Utils {
 	}
 
 
-	public static boolean useDaylightTime(double latitude, double longitude) {
-		TimeZone gpsPointTimeZone = getTimeZoneFromLatLon(latitude, longitude);
-		return gpsPointTimeZone.useDaylightTime();
-	}
-
-
 	/**
 	 * Converts a Joda-Time to a date for a SpinnerDateModel. The particularity of
 	 * the SpinnerDateModel is that it is time zone agnostic. Hence we need to keep


### PR DESCRIPTION
When loading a GPX, we get the timezone of the first GPS point to know the offset from UTC.
That way, the times loaded are valid.

Also, when displaying the sunrise/sunset and course start times (Track Settings dialog), there was a bug and the time was not real time but the UTC time.